### PR TITLE
Draft schemas for handling concurrent customer validations (OFAC, etc)

### DIFF
--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -3354,6 +3354,11 @@ components:
         purposeOfRemittance:
           type: integer
           default: 1
+        validationPending:
+          type: boolean
+          default: false
+          description: | 
+              If true, the transfer will be created in a validation pending state, indicating that the customer needs to confirm the outcome of their validations by calling [endpoint reference here] before the transfer can be completed.
         fields:
           type: array
           items:


### PR DESCRIPTION
Proposed schema changes to allow customers to run their own validations concurrently with those performed by RR.
