### PR TITLE
updating requirements for post recipient and transfer endpoints.

### DIFF
--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -993,14 +993,14 @@ paths:
         explode: true
         schema:
           "$ref": "#/components/schemas/transferMethods"
-      - name: recipientType
+      - name: userType
         in: query
         description: The type of recipient. See [Recipient Type](https://developer.readyremit.com/reference/enum-types#recipient-type).
         required: true
         style: form
         explode: true
         schema:
-          "$ref": "#/components/schemas/recipientTypes"
+          "$ref": "#/components/schemas/userTypes"
       responses:
         '200':
           description: The request was successful, and the response contains a collection of field sets. Each field set includes a collection of fields with details such as field type, length constraints, and whether the field is required.
@@ -7252,7 +7252,7 @@ components:
         - fields
       properties:
         userType:
-          "$ref": "#/components/schemas/recipientTypes"
+          "$ref": "#/components/schemas/userTypes"
           description: The type of recipient. See [Recipient Type](https://developer.readyremit.com/reference/enum-types#recipient-type).
         dstCountryIso3Code:
           "$ref": "#/components/schemas/threeUppercaseChars"
@@ -7453,6 +7453,9 @@ components:
       enum:
       - BUSINESS
       - PERSON
+    userTypes:
+      allOf:
+        - $ref: '#/components/schemas/recipientTypes'
     senderTypes:
       type: string
       description: |

--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -7251,9 +7251,19 @@ components:
         - recipientType
         - fields
       properties:
-        recipientType:
+        userType:
           "$ref": "#/components/schemas/recipientTypes"
           description: The type of recipient. See [Recipient Type](https://developer.readyremit.com/reference/enum-types#recipient-type).
+        dstCountryIso3Code:
+          "$ref": "#/components/schemas/threeUppercaseChars"
+          description: The ISO 3166-1 alpha-3 code of the destination country.
+        dstCurrencyIso3Code:
+          description: The ISO 4217 code of the currency of the amount you would like to receive money. A string of exactly 3 uppercase alphabetical characters. This code is used to identify the currency in which the recipient will receive the funds.
+          type: string
+          pattern: "^[A-Z]{3}$"
+        transferMethod:
+          "$ref": "#/components/schemas/transferMethods"
+          description: The method of transfer (BANK_ACCOUNT, CASH_PICKUP, etc.).
         senderId:
           type: string
           description: Unique identifier for the sender.
@@ -7316,6 +7326,9 @@ components:
           type: integer
           description:  >
             Numeric value. The amount the sender wishes to transfer. Example- If you want to send 100 USD, this would be 10000. See [how to format an amount based on the currency you would like to send or receive money](https://developer.readyremit.com/reference/currencies).
+        quoteHistoryId:
+          type: string
+          description: The quote history ID from the GET /quote endpoint response.
         # senderId:
         #   type: string
         recipientId:

--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -993,14 +993,14 @@ paths:
         explode: true
         schema:
           "$ref": "#/components/schemas/transferMethods"
-      - name: userType
+      - name: recipientType
         in: query
         description: The type of recipient. See [Recipient Type](https://developer.readyremit.com/reference/enum-types#recipient-type).
         required: true
         style: form
         explode: true
         schema:
-          "$ref": "#/components/schemas/userTypes"
+          "$ref": "#/components/schemas/recipientTypes"
       responses:
         '200':
           description: The request was successful, and the response contains a collection of field sets. Each field set includes a collection of fields with details such as field type, length constraints, and whether the field is required.


### PR DESCRIPTION
[AB#102882](https://dev.azure.com/brightwell/74ec2b30-acae-4162-9959-2d5d2f95a478/_workitems/edit/102882)

## What's included
updating following endpoints:
POST /recipient: dstCountryIso3Code, dstCurrencyIso3Code, userType, transferMethod (NOTE: recipientType was renamed to userType in 2022 but was not updated/reflected in documentation.)
<img width="1117" height="796" alt="image" src="https://github.com/user-attachments/assets/875f759b-fba5-4edb-9375-e8d68ff249b4" />

POST /transfer: quoteHistoryId
![image](https://github.com/user-attachments/assets/dbe8b5b7-c4cc-4403-9972-aedd373bab50)

## Anything specific to note or review
it would be nice to also mark some of these prams as required, but since we shared some of these components with other endpoints it may cause confusion. A future enhancement for this for sure.