### PR TITLE
ADDRESS_ZIP in the field enum

### DIFF
--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -9207,6 +9207,7 @@ components:
           - ADDRESS_LINE_1
           - ADDRESS_CITY
           - ADDRESS_STATE
+          - ADDRESS_ZIP
           - ADDRESS_COUNTRY
           - DATE_OF_BIRTH
           - EMAIL_ADDRESS


### PR DESCRIPTION
- Updated the enum to have ADDRESS_ZIP.  Verified no issues with it being used elsewhere.  Visually verified it in the OpenAPI preview in the Senders, Recipients, and Recipient Accounts endpoint

**POST /sender request**
<img width="1236" height="463" alt="image" src="https://github.com/user-attachments/assets/8a1e5c1f-1b19-4558-9bcc-910662cb7cd6" />

