### PR TITLE
NFCU "Issue" Fixes/Adjustents

### DIFF
--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -9110,7 +9110,7 @@ components:
     baseField:
       required:
       - fieldType
-      - id
+      - fieldId
       - name
       # - required
       type: object

--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -8148,7 +8148,7 @@ components:
     createRecipientRequest:
       type: object
       required:
-        - recipientType
+        - userType
         - fields
       properties:
         userType:

--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -2177,7 +2177,6 @@ paths:
                 oneOf:
                   - "$ref": "#/components/schemas/fieldSetsObject"
                   - "$ref": "#/components/schemas/recipientAccountMobileWallet"
-                  - "$ref": "#/components/schemas/fieldSetsObject"
               examples:
                 Bank Account:
                   summary: Bank Account

--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -7997,7 +7997,7 @@ components:
       - expiryDate
       - cvv2
       properties:
-        cardonboardingsessionid:
+        cardOnboardingSessionId:
           type: string
           description: "The unique identifier for the card onboarding session. This ID is used to track and manage the session within the system. Example: 'e22e6884-ae4d-4bd9-aa1d-e28b6b894bac'"
         cardholderName:

--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -5530,6 +5530,7 @@ paths:
       tags:
         - Transfers
       summary: Get Transfers
+      operationId: getTransfers
       description:  >
         The `GET /transfers` endpoint retrieves a list of transfers based on the provided query parameters. This operation allows you to filter and paginate through the list of transfers. It is useful for fetching transfer records associated with a specific sender, and for managing large datasets by limiting the number of records returned in a single request and skipping a specified number of records.
 


### PR DESCRIPTION
# Fix OpenAPI spec issues blocking code generation
Changes
- [1] GET /transfers — Added missing operationId: getTransfers to match the naming convention of sibling operations
- [5] createRecipientRequest — Fixed required list: changed recipientType → userType to match the actual property name
- [7] createCardRequest — Fixed property casing: renamed cardonboardingsessionid → cardOnboardingSessionId to match the camelCase name in the required list and the example
- [6] baseField — Fixed required list: changed id → fieldId to match the actual property name, consistent with all response examples and usages in GET /recipient-account-fields and GET /sender-fields
- GET /recipient-account-fields — Removed duplicate fieldSetsObject entry from the oneOf response schema, leaving fieldSetsObject and recipientAccountMobileWallet as the two valid variants