### PR TITLE
868k2kt8u Document isDeactivated sender flag in Transfer API spec

### DIFF
--- a/postman/schemas/transfer.yml
+++ b/postman/schemas/transfer.yml
@@ -3517,6 +3517,10 @@ paths:
                         description: |
                             Specifies the method the customer uses to fund transactions, ensuring appropriate payment processing. Example: PREFUNDING
                             Note: This field can be ignored by API consumers.
+                    isDeactivated:
+                        type: boolean
+                        readOnly: true
+                        description: "`true` when the sender's status is `INACTIVE` or the sender has been deleted; `false` for `ACTIVE` or `INCOMPLETE`. Always present in the response."
                     fields:
                           type: array
                           description: A collection of detailed sender attributes, each providing additional information about the sender.
@@ -3534,6 +3538,7 @@ paths:
                     customerId: 9ce909de-f585-4233-bdc5-fdc42cbfd7c4
                     kycStatus: SKIPPED
                     customerFundingSource: PREFUNDING
+                    isDeactivated: false
                     fields:
                       - id: FIRST_NAME
                         name: LegalFirstName
@@ -3611,6 +3616,7 @@ paths:
                     customerId: 9ce909de-f585-4233-bdc5-fdc42cbfd7c4
                     kycStatus: SKIPPED
                     customerFundingSource: PREFUNDING
+                    isDeactivated: false
                     fields:
                       - id: COMPANY_NAME
                         name: Company name
@@ -3748,6 +3754,7 @@ paths:
                     customerName: BWP Cruises
                     kycStatus: SKIPPED
                     customerFundingSource: PREFUNDING
+                    isDeactivated: false
                     fields:
                       - id: FIRST_NAME
                         name: LegalFirstName
@@ -3826,6 +3833,7 @@ paths:
                     customerName: "BWP Shipping"
                     kycStatus: "SKIPPED"
                     customerFundingSource: "PREFUNDING"
+                    isDeactivated: false
                     fields:
                       - id: "COMPANY_NAME"
                         name: "Company name"
@@ -4058,6 +4066,7 @@ paths:
                   summary: PERSON
                   value:
                     senderType: PERSON
+                    isDeactivated: false
                     fields:
                       - id: FIRST_NAME
                         name: LegalFirstName
@@ -4136,6 +4145,7 @@ paths:
                     customerId: 9ce909de-f585-4233-bdc5-fdc42cbfd7c4
                     kycStatus: SKIPPED
                     customerFundingSource: PREFUNDING
+                    isDeactivated: false
                     fields:
                       - id: COMPANY_NAME
                         name: Company name
@@ -4297,6 +4307,7 @@ paths:
                   summary: PERSON
                   value:
                     senderType: PERSON
+                    isDeactivated: false
                     fields:
                       - id: FIRST_NAME
                         name: LegalFirstName
@@ -4375,6 +4386,7 @@ paths:
                     customerId: 9ce909de-f585-4233-bdc5-fdc42cbfd7c4
                     kycStatus: SKIPPED
                     customerFundingSource: PREFUNDING
+                    isDeactivated: false
                     fields:
                       - id: COMPANY_NAME
                         name: Company name
@@ -9116,6 +9128,10 @@ components:
           description: "Company name if the sender type is Business. Example: 'BWP Cruises'"
         kycStatus:
           "$ref": "#/components/schemas/kycStatuses"
+        isDeactivated:
+          type: boolean
+          readOnly: true
+          description: "`true` when the sender's status is `INACTIVE` or the sender has been deleted; `false` for `ACTIVE` or `INCOMPLETE`. Always present in the response."
         fields:
           type: array
           items:


### PR DESCRIPTION
## Summary

- Adds the read-only boolean `isDeactivated` to the `sender` component schema (covers `getSender`, `updateSender`, and `patchSender` responses, which all `$ref` that schema)
- Adds `isDeactivated` to the `createSender` inline response schema (that endpoint uses its own inline object, not a `$ref`)
- Adds `isDeactivated: false` to all eight response example payloads (Person + Business for each of the four endpoints)

Paired with feature ticket [868k145bq](https://app.clickup.com/t/868k145bq), which adds the derived field to the API code. Documented as `readOnly: true`, always present, with a description conveying the `INACTIVE`/deleted → `true`, `ACTIVE`/`INCOMPLETE` → `false` derivation.

**Not changed:** `deleteSender`, OFAC/hold actions, the `senderDetails` snapshot in transfer responses.

## Test plan

- [ ] OpenAPI lint passes against `postman/schemas/transfer.yml`
- [ ] `isDeactivated` appears in both schema definitions and all eight example payloads (grep the file)
- [ ] After merge to `main`, verify the field renders correctly in the ReadMe developer portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)